### PR TITLE
ConstLabels weren't being assigned due to empty help

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,25 +68,25 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			labels := CreateResourceLabels(value.ID)
 
 			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(metricName+"_total", "", nil, labels),
+				prometheus.NewDesc(metricName+"_total", metricName+"_total", nil, labels),
 				prometheus.GaugeValue,
 				metricValue.Total,
 			)
 
 			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(metricName+"_average", "", nil, labels),
+				prometheus.NewDesc(metricName+"_average", metricName+"_average", nil, labels),
 				prometheus.GaugeValue,
 				metricValue.Average,
 			)
 
 			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(metricName+"_min", "", nil, labels),
+				prometheus.NewDesc(metricName+"_min", metricName+"_min", nil, labels),
 				prometheus.GaugeValue,
 				metricValue.Minimum,
 			)
 
 			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(metricName+"_max", "", nil, labels),
+				prometheus.NewDesc(metricName+"_max", metricName+"_max", nil, labels),
 				prometheus.GaugeValue,
 				metricValue.Maximum,
 			)


### PR DESCRIPTION
The empty help string causes the call to `NewDesc` to return before setting up labels: [desc.go](https://github.com/prometheus/client_golang/blob/b5bfa0eb2c8d46bd91dc58271e973c5f0bbebcfa/prometheus/desc.go#L83). Thus all the labels sent in are ignored. This PR simply sets the help to the metric name.