### PR TITLE
Allow selecting aggregations per resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,16 @@ targets:
     - name: "BytesReceived"
     - name: "BytesSent"
   - resource: "azure_resource_id"
+    aggregations:
+    - Minimum
+    - Maximum
+    - Average
     metrics:
     - name: "Http2xx"
     - name: "Http5xx"
 ```
+
+By default, all aggregations are returned (`Total`, `Maximum`, `Average`, `Minimum`). It can be overridden per resource.
 
 # Example Prometheus config
 

--- a/azure.go
+++ b/azure.go
@@ -170,7 +170,7 @@ func (ac *AzureClient) getMetricValue(metricNames string, target config.Target) 
 	if metricNames != "" {
 		values.Add("metricnames", metricNames)
 	}
-	if target.Aggregations != nil && len(target.Aggregations) > 0 {
+	if len(target.Aggregations) > 0 {
 		values.Add("aggregation", strings.Join(target.Aggregations, ","))
 	} else {
 		values.Add("aggregation", "Total,Average,Minimum,Maximum")

--- a/azure.go
+++ b/azure.go
@@ -8,7 +8,10 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
+
+	"github.com/RobustPerception/azure_metrics_exporter/config"
 )
 
 // AzureMetricDefinitionResponse represents metric definition response for a given resource from Azure.
@@ -144,7 +147,7 @@ func (ac *AzureClient) getMetricDefinitions() map[string]AzureMetricDefinitionRe
 	return definitions
 }
 
-func (ac *AzureClient) getMetricValue(metricNames string, target string) AzureMetricValueResponse {
+func (ac *AzureClient) getMetricValue(metricNames string, target config.Target) AzureMetricValueResponse {
 	apiVersion := "2018-01-01"
 	now := time.Now().UTC()
 	refreshAt := ac.accessTokenExpiresOn.Add(-10 * time.Minute)
@@ -152,7 +155,7 @@ func (ac *AzureClient) getMetricValue(metricNames string, target string) AzureMe
 		ac.getAccessToken()
 	}
 
-	metricsResource := fmt.Sprintf("subscriptions/%s%s", sc.C.Credentials.SubscriptionID, target)
+	metricsResource := fmt.Sprintf("subscriptions/%s%s", sc.C.Credentials.SubscriptionID, target.Resource)
 	endTime, startTime := GetTimes()
 
 	metricValueEndpoint := fmt.Sprintf("https://management.azure.com/%s/providers/microsoft.insights/metrics", metricsResource)
@@ -167,7 +170,11 @@ func (ac *AzureClient) getMetricValue(metricNames string, target string) AzureMe
 	if metricNames != "" {
 		values.Add("metricnames", metricNames)
 	}
-	values.Add("aggregation", "Total,Average,Minimum,Maximum")
+	if target.Aggregations != nil && len(target.Aggregations) > 0 {
+		values.Add("aggregation", strings.Join(target.Aggregations, ","))
+	} else {
+		values.Add("aggregation", "Total,Average,Minimum,Maximum")
+	}
 	values.Add("timespan", fmt.Sprintf("%s/%s", startTime, endTime))
 	values.Add("api-version", apiVersion)
 

--- a/config/config.go
+++ b/config/config.go
@@ -37,10 +37,34 @@ func (sc *SafeConfig) ReloadConfig(confFile string) (err error) {
 		return fmt.Errorf("Error parsing config file: %s", err)
 	}
 
+	if err := c.Validate(); err != nil {
+		return fmt.Errorf("Error validating config file: %s", err)
+	}
+
 	sc.Lock()
 	sc.C = c
 	sc.Unlock()
 
+	return nil
+}
+
+var validAggregations = []string{"Total", "Average", "Minimum", "Maximum"}
+
+func (c *Config) Validate() (err error) {
+	for _, t := range c.Targets {
+		for _, a := range t.Aggregations {
+			ok := false
+			for _, valid := range validAggregations {
+				if a == valid {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				return fmt.Errorf("%s is not one of the valid aggregations (%v)", a, validAggregations)
+			}
+		}
+	}
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -56,8 +56,9 @@ type Credentials struct {
 
 // Target represents Azure target resource and its associated metric definitions
 type Target struct {
-	Resource string   `yaml:"resource"`
-	Metrics  []Metric `yaml:"metrics"`
+	Resource     string   `yaml:"resource"`
+	Metrics      []Metric `yaml:"metrics"`
+	Aggregations []string `yaml:"aggregations"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			metricValue := value.Timeseries[0].Data[len(value.Timeseries[0].Data)-1]
 			labels := CreateResourceLabels(value.ID)
 
-			if hasAggregation(target, "total") {
+			if hasAggregation(target, "Total") {
 				ch <- prometheus.MustNewConstMetric(
 					prometheus.NewDesc(metricName+"_total", metricName+"_total", nil, labels),
 					prometheus.GaugeValue,
@@ -75,7 +75,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 				)
 			}
 
-			if hasAggregation(target, "average") {
+			if hasAggregation(target, "Average") {
 				ch <- prometheus.MustNewConstMetric(
 					prometheus.NewDesc(metricName+"_average", metricName+"_average", nil, labels),
 					prometheus.GaugeValue,
@@ -83,7 +83,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 				)
 			}
 
-			if hasAggregation(target, "minimum") {
+			if hasAggregation(target, "Minimum") {
 
 				ch <- prometheus.MustNewConstMetric(
 					prometheus.NewDesc(metricName+"_min", metricName+"_min", nil, labels),
@@ -92,7 +92,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 				)
 			}
 
-			if hasAggregation(target, "maximum") {
+			if hasAggregation(target, "Maximum") {
 				ch <- prometheus.MustNewConstMetric(
 					prometheus.NewDesc(metricName+"_max", metricName+"_max", nil, labels),
 					prometheus.GaugeValue,

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			metrics = append(metrics, metric.Name)
 		}
 		metricsStr := strings.Join(metrics, ",")
-		metricValueData = ac.getMetricValue(metricsStr, target.Resource)
+		metricValueData = ac.getMetricValue(metricsStr, target)
 		if metricValueData.Value == nil {
 			log.Printf("Metric %v not found at target %v\n", metricsStr, target.Resource)
 			continue
@@ -67,29 +67,38 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			metricValue := value.Timeseries[0].Data[len(value.Timeseries[0].Data)-1]
 			labels := CreateResourceLabels(value.ID)
 
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(metricName+"_total", metricName+"_total", nil, labels),
-				prometheus.GaugeValue,
-				metricValue.Total,
-			)
+			if hasAggregation(target, "total") {
+				ch <- prometheus.MustNewConstMetric(
+					prometheus.NewDesc(metricName+"_total", metricName+"_total", nil, labels),
+					prometheus.GaugeValue,
+					metricValue.Total,
+				)
+			}
 
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(metricName+"_average", metricName+"_average", nil, labels),
-				prometheus.GaugeValue,
-				metricValue.Average,
-			)
+			if hasAggregation(target, "average") {
+				ch <- prometheus.MustNewConstMetric(
+					prometheus.NewDesc(metricName+"_average", metricName+"_average", nil, labels),
+					prometheus.GaugeValue,
+					metricValue.Average,
+				)
+			}
 
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(metricName+"_min", metricName+"_min", nil, labels),
-				prometheus.GaugeValue,
-				metricValue.Minimum,
-			)
+			if hasAggregation(target, "minimum") {
 
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(metricName+"_max", metricName+"_max", nil, labels),
-				prometheus.GaugeValue,
-				metricValue.Maximum,
-			)
+				ch <- prometheus.MustNewConstMetric(
+					prometheus.NewDesc(metricName+"_min", metricName+"_min", nil, labels),
+					prometheus.GaugeValue,
+					metricValue.Minimum,
+				)
+			}
+
+			if hasAggregation(target, "maximum") {
+				ch <- prometheus.MustNewConstMetric(
+					prometheus.NewDesc(metricName+"_max", metricName+"_max", nil, labels),
+					prometheus.GaugeValue,
+					metricValue.Maximum,
+				)
+			}
 		}
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -40,7 +40,7 @@ func CreateResourceLabels(resourceID string) map[string]string {
 
 func hasAggregation(t config.Target, aggregation string) bool {
 	for _, aggr := range t.Aggregations {
-		if strings.ToLower(aggr) == strings.ToLower(aggregation) {
+		if aggr == aggregation {
 			return true
 		}
 	}

--- a/utils.go
+++ b/utils.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"strings"
 	"time"
+
+	"github.com/RobustPerception/azure_metrics_exporter/config"
 )
 
 // PrintPrettyJSON - Prints structs nicely for debugging.
@@ -34,4 +36,13 @@ func CreateResourceLabels(resourceID string) map[string]string {
 	labels["resource_group"] = strings.Split(resourceID, "/")[4]
 	labels["resource_name"] = strings.Split(resourceID, "/")[8]
 	return labels
+}
+
+func hasAggregation(t config.Target, aggregation string) bool {
+	for _, aggr := range t.Aggregations {
+		if strings.ToLower(aggr) == strings.ToLower(aggregation) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This PR extends the config file with `aggregations`, a list of aggregations to query Azure for. If not given, the same list (total, min, max, avg) as was previously always used is used.

Fixes #17