### PR TITLE
Validate that the resource path has a leading /

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,10 @@ func (c *Config) Validate() (err error) {
 				return fmt.Errorf("%s is not one of the valid aggregations (%v)", a, validAggregations)
 			}
 		}
+
+		if !strings.HasPrefix(t.Resource, "/") {
+			return fmt.Errorf("Resource path %q must start with a /", t.Resource)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
If mis-copy/pasting or misunderstanding the config format and omitting the leading / in the resource path, the errors aren't really clear since you get a 404 on the concatenation of subscription id and the first path component.
This PR extends the config validation to check that the path begins with /