### PR TITLE
Use common/log

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/RobustPerception/azure_metrics_exporter/config"
+	"github.com/prometheus/common/log"
 )
 
 // AzureMetricDefinitionResponse represents metric definition response for a given resource from Azure.
@@ -188,7 +188,7 @@ func (ac *AzureClient) getMetricValue(metricNames string, target config.Target) 
 
 	req.URL.RawQuery = values.Encode()
 
-	log.Printf("GET %s", req.URL)
+	log.Infof("GET %s", req.URL)
 	resp, err := ac.client.Do(req)
 	if err != nil {
 		return AzureMetricValueResponse{}, fmt.Errorf("Error: %v", err)

--- a/utils.go
+++ b/utils.go
@@ -1,23 +1,11 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
-	"log"
 	"strings"
 	"time"
 
 	"github.com/RobustPerception/azure_metrics_exporter/config"
 )
-
-// PrintPrettyJSON - Prints structs nicely for debugging.
-func PrintPrettyJSON(input map[string]interface{}) {
-	out, err := json.MarshalIndent(input, "", "\t")
-	if err != nil {
-		log.Fatalf("Error indenting JSON: %v", err)
-	}
-	fmt.Println(string(out))
-}
 
 // GetTimes - Returns the endTime and startTime used for querying Azure Metrics API
 func GetTimes() (string, string) {


### PR DESCRIPTION
Switch to common/log, so we can use the same logging options as in other exporters, especially json-formatting.