### PR TITLE
Handle potentially missing values

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -209,5 +209,9 @@ func (ac *AzureClient) getMetricValue(metricNames string, target config.Target) 
 		return AzureMetricValueResponse{}, fmt.Errorf("Error unmarshalling response body: %v", err)
 	}
 
+	if data.APIError.Code != "" {
+		return AzureMetricValueResponse{}, fmt.Errorf("Metrics API returned error: %s - %v", data.APIError.Code, data.APIError.Message)
+	}
+
 	return data, nil
 }

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			continue
 		}
 
-		if metricValueData.Value == nil {
+		if len(metricValueData.Value) == 0 || len(metricValueData.Value[0].Timeseries) == 0 {
 			log.Printf("Metric %v not found at target %v\n", metricsStr, target.Resource)
 			continue
 		}


### PR DESCRIPTION
We got a number of "index out of range" panics tonight on this row: https://github.com/RobustPerception/azure_metrics_exporter/blob/9660d183bd1fc1f6eda6580b130aefc6b24ca60b/main.go#L60

This PR extends the checks done before accessing this value to avoid the panic.

Additionally, I noticed that there is an `APIError` field returned from Azure that we never checked. I'm not sure if it was set when these "no value" entries were returned, but I added some checks for it as well. Hopefully it would catch this earlier, and also give some info on why it happens.