### PR TITLE
Serve all metric aggregates when none is specified

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -39,6 +39,11 @@ func CreateResourceLabels(resourceID string) map[string]string {
 }
 
 func hasAggregation(t config.Target, aggregation string) bool {
+	// Serve all aggregations when none is specified in the config
+	if len(t.Aggregations) == 0 {
+		return true
+	}
+
 	for _, aggr := range t.Aggregations {
 		if aggr == aggregation {
 			return true


### PR DESCRIPTION
The readme says:
```
By default, all aggregations are returned (`Total`, `Maximum`, `Average`, `Minimum`). It can be overridden per resource.
```

However without an `aggregations` key in the config no metric is returned. This pull request fixes this by returning all aggregations instead.