### PR TITLE
Add ability to gather all resources from a resource group

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,19 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9276']
 ```
+
+# Resource group filtering
+
+Resources in a resource group can be filtered using the the following keys:
+
+`resource_types`:
+List of resource types to include (corresponds to the `Resource type` column in the Azure portal).
+
+`resource_include`:
+List of regexps that is matched against the resource name.
+Metrics of all matched resources are exported (defaults to include all)
+
+`resource_exclude`:
+List of regexps that is matched against the resource name.
+Metrics of all matched resources are ignored (defaults to exclude none)
+Excludes take precedence over the include filter.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ targets:
     metrics:
     - name: "Http2xx"
     - name: "Http5xx"
+
+resource_groups:
+  - resource_group: "webapps"
+    resource_types:
+    - "Microsoft.Compute/virtualMachines"
+    resource_include:
+    - "^testvm"
+    resource_exclude:
+    - "^testvm12$"
+    metrics:
+    - name: "CPU Credits Consumed"
+
 ```
 
 By default, all aggregations are returned (`Total`, `Maximum`, `Average`, `Minimum`). It can be overridden per resource.

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ resource_groups:
     resource_types:
     - "Microsoft.Compute/virtualMachines"
     resource_name_include_re:
-    - "^testvm"
+    - "testvm.*"
     resource_name_exclude_re:
-    - "^testvm12$"
+    - "testvm12"
     metrics:
     - name: "CPU Credits Consumed"
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ resource_groups:
   - resource_group: "webapps"
     resource_types:
     - "Microsoft.Compute/virtualMachines"
-    resource_include:
+    resource_name_include_re:
     - "^testvm"
-    resource_exclude:
+    resource_name_exclude_re:
     - "^testvm12$"
     metrics:
     - name: "CPU Credits Consumed"
@@ -85,11 +85,11 @@ Resources in a resource group can be filtered using the the following keys:
 `resource_types`:
 List of resource types to include (corresponds to the `Resource type` column in the Azure portal).
 
-`resource_include`:
+`resource_name_include_re`:
 List of regexps that is matched against the resource name.
 Metrics of all matched resources are exported (defaults to include all)
 
-`resource_exclude`:
+`resource_name_exclude_re`:
 List of regexps that is matched against the resource name.
 Metrics of all matched resources are ignored (defaults to exclude none)
 Excludes take precedence over the include filter.

--- a/azure-example.yml
+++ b/azure-example.yml
@@ -15,3 +15,8 @@ targets:
     metrics:
     - name: "Http2xx"
     - name: "Http5xx"
+  - resource_group: "webapps"
+    resource_types:
+    - "Microsoft.Compute/virtualMachines"
+    metrics:
+    - name: "CPU Credits Consumed"

--- a/azure-example.yml
+++ b/azure-example.yml
@@ -20,9 +20,9 @@ resource_groups:
   - resource_group: "webapps"
     resource_types:
     - "Microsoft.Compute/virtualMachines"
-    resource_include:
+    resource_name_include_re:
     - "^testvm"
-    resource_exclude:
+    resource_name_exclude_re:
     - "^testvm12$"
     metrics:
     - name: "CPU Credits Consumed"

--- a/azure-example.yml
+++ b/azure-example.yml
@@ -20,5 +20,9 @@ resource_groups:
   - resource_group: "webapps"
     resource_types:
     - "Microsoft.Compute/virtualMachines"
+    resource_include:
+    - "^testvm"
+    resource_exclude:
+    - "^testvm12$"
     metrics:
     - name: "CPU Credits Consumed"

--- a/azure-example.yml
+++ b/azure-example.yml
@@ -21,8 +21,8 @@ resource_groups:
     resource_types:
     - "Microsoft.Compute/virtualMachines"
     resource_name_include_re:
-    - "^testvm"
+    - "testvm.*"
     resource_name_exclude_re:
-    - "^testvm12$"
+    - "testvm12"
     metrics:
     - name: "CPU Credits Consumed"

--- a/azure-example.yml
+++ b/azure-example.yml
@@ -15,6 +15,8 @@ targets:
     metrics:
     - name: "Http2xx"
     - name: "Http5xx"
+
+resource_groups:
   - resource_group: "webapps"
     resource_types:
     - "Microsoft.Compute/virtualMachines"

--- a/azure.go
+++ b/azure.go
@@ -10,8 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/RobustPerception/azure_metrics_exporter/config"
 )
 
 // AzureMetricDefinitionResponse represents metric definition response for a given resource from Azure.
@@ -152,7 +150,7 @@ func (ac *AzureClient) getMetricDefinitions() (map[string]AzureMetricDefinitionR
 	return definitions, nil
 }
 
-func (ac *AzureClient) getMetricValue(metricNames string, target config.Target) (AzureMetricValueResponse, error) {
+func (ac *AzureClient) getMetricValue(resource string, metricNames string, aggregations []string) (AzureMetricValueResponse, error) {
 	apiVersion := "2018-01-01"
 	now := time.Now().UTC()
 	refreshAt := ac.accessTokenExpiresOn.Add(-10 * time.Minute)
@@ -163,7 +161,7 @@ func (ac *AzureClient) getMetricValue(metricNames string, target config.Target) 
 		}
 	}
 
-	metricsResource := fmt.Sprintf("subscriptions/%s%s", sc.C.Credentials.SubscriptionID, target.Resource)
+	metricsResource := fmt.Sprintf("subscriptions/%s%s", sc.C.Credentials.SubscriptionID, resource)
 	endTime, startTime := GetTimes()
 
 	metricValueEndpoint := fmt.Sprintf("https://management.azure.com/%s/providers/microsoft.insights/metrics", metricsResource)
@@ -178,8 +176,8 @@ func (ac *AzureClient) getMetricValue(metricNames string, target config.Target) 
 	if metricNames != "" {
 		values.Add("metricnames", metricNames)
 	}
-	if len(target.Aggregations) > 0 {
-		values.Add("aggregation", strings.Join(target.Aggregations, ","))
+	if len(aggregations) > 0 {
+		values.Add("aggregation", strings.Join(aggregations, ","))
 	} else {
 		values.Add("aggregation", "Total,Average,Minimum,Maximum")
 	}

--- a/azure.go
+++ b/azure.go
@@ -162,14 +162,6 @@ func (ac *AzureClient) getMetricDefinitions() (map[string]AzureMetricDefinitionR
 
 func (ac *AzureClient) getMetricValue(resource string, metricNames string, aggregations []string) (AzureMetricValueResponse, error) {
 	apiVersion := "2018-01-01"
-	now := time.Now().UTC()
-	refreshAt := ac.accessTokenExpiresOn.Add(-10 * time.Minute)
-	if now.After(refreshAt) {
-		err := ac.getAccessToken()
-		if err != nil {
-			return AzureMetricValueResponse{}, fmt.Errorf("Error refreshing access token: %v", err)
-		}
-	}
 
 	metricsResource := fmt.Sprintf("subscriptions/%s%s", sc.C.Credentials.SubscriptionID, resource)
 	endTime, startTime := GetTimes()
@@ -226,14 +218,6 @@ func (ac *AzureClient) getMetricValue(resource string, metricNames string, aggre
 
 func (ac *AzureClient) listFromResourceGroup(resourceGroup string, resourceTypes []string) ([]string, error) {
 	apiVersion := "2018-02-01"
-	now := time.Now().UTC()
-	refreshAt := ac.accessTokenExpiresOn.Add(-10 * time.Minute)
-	if now.After(refreshAt) {
-		err := ac.getAccessToken()
-		if err != nil {
-			return nil, fmt.Errorf("Error refreshing access token: %v", err)
-		}
-	}
 
 	var filterTypesElements []string
 	for _, filterType := range resourceTypes {
@@ -284,4 +268,17 @@ func (ac *AzureClient) listFromResourceGroup(resourceGroup string, resourceTypes
 	}
 
 	return resources, nil
+}
+
+func (ac *AzureClient) refreshAccessToken() error {
+	now := time.Now().UTC()
+	refreshAt := ac.accessTokenExpiresOn.Add(-10 * time.Minute)
+	if now.After(refreshAt) {
+		err := ac.getAccessToken()
+		if err != nil {
+			return fmt.Errorf("Error refreshing access token: %v", err)
+		}
+	}
+
+	return nil
 }

--- a/azure.go
+++ b/azure.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -188,7 +187,6 @@ func (ac *AzureClient) getMetricValue(resource string, metricNames string, aggre
 
 	req.URL.RawQuery = values.Encode()
 
-	log.Printf("GET %s", req.URL)
 	resp, err := ac.client.Do(req)
 	if err != nil {
 		return AzureMetricValueResponse{}, fmt.Errorf("Error: %v", err)
@@ -234,8 +232,6 @@ func (ac *AzureClient) listFromResourceGroup(resourceGroup string, resourceTypes
 		return nil, fmt.Errorf("Error creating HTTP request: %v", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+ac.accessToken)
-
-	log.Printf("GET %s", req.URL)
 
 	resp, err := ac.client.Do(req)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -65,7 +65,15 @@ func (c *Config) Validate() (err error) {
 			}
 		}
 
-		if !strings.HasPrefix(t.Resource, "/") {
+		if len(t.Resource) == 0 && len(t.ResourceGroup) == 0 {
+			return fmt.Errorf("resource or resoure_group needs to be specified in each target")
+		}
+
+		if len(t.Resource) != 0 && len(t.ResourceGroup) != 0 {
+			return fmt.Errorf("Only one of resource and resoure_group can be specified in each target")
+		}
+
+		if len(t.Resource) != 0 && !strings.HasPrefix(t.Resource, "/") {
 			return fmt.Errorf("Resource path %q must start with a /", t.Resource)
 		}
 	}
@@ -84,9 +92,11 @@ type Credentials struct {
 
 // Target represents Azure target resource and its associated metric definitions
 type Target struct {
-	Resource     string   `yaml:"resource"`
-	Metrics      []Metric `yaml:"metrics"`
-	Aggregations []string `yaml:"aggregations"`
+	Resource      string   `yaml:"resource"`
+	ResourceGroup string   `yaml:"resource_group"`
+	ResourceTypes []string `yaml:"resource_types"`
+	Metrics       []Metric `yaml:"metrics"`
+	Aggregations  []string `yaml:"aggregations"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -86,6 +87,12 @@ func (c *Config) Validate() (err error) {
 		if len(t.Metrics) == 0 {
 			return fmt.Errorf("At least one metric needs to be specified in each resource group")
 		}
+
+		for _, rx := range append(t.ResourceInclude, t.ResourceExclude...) {
+			if _, err := regexp.Compile(rx); err != nil {
+				return fmt.Errorf("Error in regexp '%s': %s", rx, err)
+			}
+		}
 	}
 
 	return nil
@@ -129,10 +136,12 @@ type Target struct {
 
 // ResourceGroup represents Azure target resource group and its associated metric definitions
 type ResourceGroup struct {
-	ResourceGroup string   `yaml:"resource_group"`
-	ResourceTypes []string `yaml:"resource_types"`
-	Metrics       []Metric `yaml:"metrics"`
-	Aggregations  []string `yaml:"aggregations"`
+	ResourceGroup   string   `yaml:"resource_group"`
+	ResourceTypes   []string `yaml:"resource_types"`
+	ResourceInclude []string `yaml:"resource_include"`
+	ResourceExclude []string `yaml:"resource_exclude"`
+	Metrics         []Metric `yaml:"metrics"`
+	Aggregations    []string `yaml:"aggregations"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -88,7 +88,7 @@ func (c *Config) Validate() (err error) {
 			return fmt.Errorf("At least one metric needs to be specified in each resource group")
 		}
 
-		for _, rx := range append(t.ResourceInclude, t.ResourceExclude...) {
+		for _, rx := range append(t.ResourceNameIncludeRe, t.ResourceNameExcludeRe...) {
 			if _, err := regexp.Compile(rx); err != nil {
 				return fmt.Errorf("Error in regexp '%s': %s", rx, err)
 			}
@@ -136,12 +136,12 @@ type Target struct {
 
 // ResourceGroup represents Azure target resource group and its associated metric definitions
 type ResourceGroup struct {
-	ResourceGroup   string   `yaml:"resource_group"`
-	ResourceTypes   []string `yaml:"resource_types"`
-	ResourceInclude []string `yaml:"resource_include"`
-	ResourceExclude []string `yaml:"resource_exclude"`
-	Metrics         []Metric `yaml:"metrics"`
-	Aggregations    []string `yaml:"aggregations"`
+	ResourceGroup         string   `yaml:"resource_group"`
+	ResourceTypes         []string `yaml:"resource_types"`
+	ResourceNameIncludeRe []string `yaml:"resource_name_include_re"`
+	ResourceNameExcludeRe []string `yaml:"resource_name_exclude_re"`
+	Metrics               []Metric `yaml:"metrics"`
+	Aggregations          []string `yaml:"aggregations"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -229,7 +229,7 @@ func (re *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal(&s); err != nil {
 		return err
 	}
-	regex, err := regexp.Compile(s)
+	regex, err := regexp.Compile("^(?:" + s + ")$")
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			metrics = append(metrics, metric.Name)
 		}
 		metricsStr := strings.Join(metrics, ",")
-		metricValueData, err := ac.getMetricValue(metricsStr, target)
+		metricValueData, err := ac.getMetricValue(target.Resource, metricsStr, target.Aggregations)
 		if err != nil {
 			log.Printf("Failed to get metrics for target %s: %v", target.Resource, err)
 			continue
@@ -71,7 +71,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			metricValue := value.Timeseries[0].Data[len(value.Timeseries[0].Data)-1]
 			labels := CreateResourceLabels(value.ID)
 
-			if hasAggregation(target, "Total") {
+			if hasAggregation(target.Aggregations, "Total") {
 				ch <- prometheus.MustNewConstMetric(
 					prometheus.NewDesc(metricName+"_total", metricName+"_total", nil, labels),
 					prometheus.GaugeValue,
@@ -79,7 +79,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 				)
 			}
 
-			if hasAggregation(target, "Average") {
+			if hasAggregation(target.Aggregations, "Average") {
 				ch <- prometheus.MustNewConstMetric(
 					prometheus.NewDesc(metricName+"_average", metricName+"_average", nil, labels),
 					prometheus.GaugeValue,
@@ -87,7 +87,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 				)
 			}
 
-			if hasAggregation(target, "Minimum") {
+			if hasAggregation(target.Aggregations, "Minimum") {
 
 				ch <- prometheus.MustNewConstMetric(
 					prometheus.NewDesc(metricName+"_min", metricName+"_min", nil, labels),
@@ -96,7 +96,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 				)
 			}
 
-			if hasAggregation(target, "Maximum") {
+			if hasAggregation(target.Aggregations, "Maximum") {
 				ch <- prometheus.MustNewConstMetric(
 					prometheus.NewDesc(metricName+"_max", metricName+"_max", nil, labels),
 					prometheus.GaugeValue,

--- a/main.go
+++ b/main.go
@@ -99,6 +99,11 @@ func (c *Collector) collectResource(ch chan<- prometheus.Metric, resource string
 
 // Collect - collect results from Azure Montior API and create Prometheus metrics.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	if err := ac.refreshAccessToken(); err != nil {
+		log.Println(err)
+		return
+	}
+
 	// Get metric values for all defined metrics
 	for _, target := range sc.C.Targets {
 		metrics := []string{}

--- a/main.go
+++ b/main.go
@@ -135,8 +135,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			if len(target.ResourceNameIncludeRe) != 0 {
 				include := false
 				for _, rx := range target.ResourceNameIncludeRe {
-					matched, err := regexp.MatchString(rx, resource_name)
-					if err == nil && matched {
+					if rx.MatchString(resource_name) {
 						include = true
 						break
 					}
@@ -149,8 +148,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 
 			exclude := false
 			for _, rx := range target.ResourceNameExcludeRe {
-				matched, err := regexp.MatchString(rx, resource_name)
-				if err == nil && matched {
+				if rx.MatchString(resource_name) {
 					exclude = true
 					break
 				}

--- a/main.go
+++ b/main.go
@@ -107,17 +107,23 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		}
 		metricsStr := strings.Join(metrics, ",")
 
-		if len(target.Resource) != 0 {
-			c.collectResource(ch, target.Resource, metricsStr, target.Aggregations)
-		} else {
-			resources, err := ac.listFromResourceGroup(target.ResourceGroup, target.ResourceTypes)
-			if err != nil {
-				continue
-			}
+		c.collectResource(ch, target.Resource, metricsStr, target.Aggregations)
+	}
 
-			for _, resource := range resources {
-				c.collectResource(ch, resource, metricsStr, target.Aggregations)
-			}
+	for _, target := range sc.C.ResourceGroups {
+		metrics := []string{}
+		for _, metric := range target.Metrics {
+			metrics = append(metrics, metric.Name)
+		}
+		metricsStr := strings.Join(metrics, ",")
+
+		resources, err := ac.listFromResourceGroup(target.ResourceGroup, target.ResourceTypes)
+		if err != nil {
+			continue
+		}
+
+		for _, resource := range resources {
+			c.collectResource(ch, resource, metricsStr, target.Aggregations)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func (c *Collector) collectResource(ch chan<- prometheus.Metric, resource string
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	if err := ac.refreshAccessToken(); err != nil {
 		log.Println(err)
+		ch <- prometheus.NewInvalidMetric(prometheus.NewDesc("azure_error", "Error collecting metrics", nil, nil), err)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -131,9 +131,9 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			resource_parts := strings.Split(resource, "/")
 			resource_name := resource_parts[len(resource_parts)-1]
 
-			if len(target.ResourceInclude) != 0 {
+			if len(target.ResourceNameIncludeRe) != 0 {
 				include := false
-				for _, rx := range target.ResourceInclude {
+				for _, rx := range target.ResourceNameIncludeRe {
 					matched, err := regexp.MatchString(rx, resource_name)
 					if err == nil && matched {
 						include = true
@@ -147,7 +147,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			}
 
 			exclude := false
-			for _, rx := range target.ResourceExclude {
+			for _, rx := range target.ResourceNameExcludeRe {
 				matched, err := regexp.MatchString(rx, resource_name)
 				if err == nil && matched {
 					exclude = true

--- a/main.go
+++ b/main.go
@@ -123,6 +123,37 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		}
 
 		for _, resource := range resources {
+			resource_parts := strings.Split(resource, "/")
+			resource_name := resource_parts[len(resource_parts)-1]
+
+			if len(target.ResourceInclude) != 0 {
+				include := false
+				for _, rx := range target.ResourceInclude {
+					matched, err := regexp.MatchString(rx, resource_name)
+					if err == nil && matched {
+						include = true
+						break
+					}
+				}
+
+				if !include {
+					continue
+				}
+			}
+
+			exclude := false
+			for _, rx := range target.ResourceExclude {
+				matched, err := regexp.MatchString(rx, resource_name)
+				if err == nil && matched {
+					exclude = true
+					break
+				}
+			}
+
+			if exclude {
+				continue
+			}
+
 			c.collectResource(ch, resource, metricsStr, target.Aggregations)
 		}
 	}

--- a/utils.go
+++ b/utils.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"strings"
 	"time"
-
-	"github.com/RobustPerception/azure_metrics_exporter/config"
 )
 
 // PrintPrettyJSON - Prints structs nicely for debugging.
@@ -38,13 +36,12 @@ func CreateResourceLabels(resourceID string) map[string]string {
 	return labels
 }
 
-func hasAggregation(t config.Target, aggregation string) bool {
-	// Serve all aggregations when none is specified in the config
-	if len(t.Aggregations) == 0 {
+func hasAggregation(aggregations []string, aggregation string) bool {
+	if len(aggregations) == 0 {
 		return true
 	}
 
-	for _, aggr := range t.Aggregations {
+	for _, aggr := range aggregations {
 		if aggr == aggregation {
 			return true
 		}


### PR DESCRIPTION
This pull requests adds the ability to collect all resources from a resource group.

I've kept the config format compatible although I think keeping single resources and resource groups separated would be better.


Changing the format from:

```
targets:
  - resource: "/resourceGroups/blog-group/providers/Microsoft.Web/sites/blog"
    metrics:
    - name: "BytesReceived"
  - resource_group: "webapps"
    resource_types:
    - "Microsoft.Compute/virtualMachines"
    metrics:
    - name: "CPU Credits Consumed"
```

to:

```
resources:
  - name: "/resourceGroups/blog-group/providers/Microsoft.Web/sites/blog"
    metrics:
      - name: "BytesReceived"

resource_groups:
  - name: "webapps"
    resource_types:
      - "Microsoft.Compute/virtualMachines"
    metrics:
      - name: "CPU Credits Consumed"
```

would avoid the possibility to create invalid configurations by specifying both resource and resource_group in a single target.
It could be kept compatible by keeping the `targets` key for single resources.
What are your thoughts on this?