### PR TITLE
Add additional label to fix SQL database scrap issue

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -31,11 +31,13 @@ func GetTimes() (string, string) {
 // CreateResourceLabels - Returns resource labels for a give resource ID.
 func CreateResourceLabels(resourceID string) map[string]string {
 	labels := make(map[string]string)
-	labels["resource_group"] = strings.Split(resourceID, "/")[4]
-	labels["resource_name"] = strings.Split(resourceID, "/")[8]
-        if len(strings.Split(resourceID, "/")) > 13 {
-	    labels["sub_resource_name"] = strings.Split(resourceID, "/")[10]
+        resource := strings.Split(resourceID, "/")
+        labels["resource_group"] = resource[4]
+        labels["resource_name"] = resource[8]
+        if len(resource) > 13 {
+            labels["sub_resource_name"] = resource[10]
         }
+
 	return labels
 }
 

--- a/utils.go
+++ b/utils.go
@@ -33,6 +33,9 @@ func CreateResourceLabels(resourceID string) map[string]string {
 	labels := make(map[string]string)
 	labels["resource_group"] = strings.Split(resourceID, "/")[4]
 	labels["resource_name"] = strings.Split(resourceID, "/")[8]
+        if len(strings.Split(resourceID, "/")) > 13 {
+	    labels["sub_resource_name"] = strings.Split(resourceID, "/")[10]
+        }
 	return labels
 }
 


### PR DESCRIPTION
Hi,

This is related to issue #40 
The exporter works only if the DB SQL server has one database with more than one this create a conflict has the exporter reports that the metric already exists. 
In fact, it's related to the label "resource_name", which takes the name of the SQL Server and not of the database. 

The resourceID for a DB:

> /subscriptions/XXXX-XXXXX-XXXXX-XXXXX-XXXXX/resourceGroups/rg-test/providers/Microsoft.Sql/servers/test-sql-server/databases/test-database-a/providers/microsoft.Insights

The solution could be to add another label to identify the database name("sub_resource_name"). 
Maybe there is the same issue with other Azure services which have long resourceID and so this change can fix it.