### PR TITLE
Manage errors that occurs while listing r.g.

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,6 +125,8 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 
 		resources, err := ac.listFromResourceGroup(target.ResourceGroup, target.ResourceTypes)
 		if err != nil {
+			log.Printf("Failed to get resources for resource group %s and resource types %s: %v",
+				target.ResourceGroup, target.ResourceTypes, err)
 			continue
 		}
 


### PR DESCRIPTION
Hi!

This PR adds an error log statement in the case where we use the resource_group configuration and there is an error connecting to the API (e.g., error 403). Currently, the exporter is silently failing if such a problem occurs.

To reproduce the problem: 
1. configure the exporter with a resource_group only
2. remove Azure Monitor reading permission from your application
3. start and call the exporter: no data is returned but no log indicates the source of the error

Thanks!