### PR TITLE
Implement --list.definitions with resource group config

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -245,6 +245,7 @@ func (ac *AzureClient) getMetricValue(resource string, metricNames string, aggre
 	return data, nil
 }
 
+// Return resource list resolved and filtered from resource_groups configuration
 func (ac *AzureClient) filteredListFromResourceGroup(resourceGroup config.ResourceGroup) ([]string, error) {
 	resources, err := ac.listFromResourceGroup(resourceGroup.ResourceGroup, resourceGroup.ResourceTypes)
 	if err != nil {
@@ -254,6 +255,7 @@ func (ac *AzureClient) filteredListFromResourceGroup(resourceGroup config.Resour
 	return filteredResources, nil
 }
 
+// Return all resources for given resource group and types
 func (ac *AzureClient) listFromResourceGroup(resourceGroup string, resourceTypes []string) ([]string, error) {
 	apiVersion := "2018-02-01"
 
@@ -306,6 +308,7 @@ func (ac *AzureClient) listFromResourceGroup(resourceGroup string, resourceTypes
 	return resources, nil
 }
 
+// Return a filtered resource list based on a given resource list and regular expressions from the configuration
 func (ac *AzureClient) filterResources(resources []string, resourceGroup config.ResourceGroup) []string {
 	filteredResources := []string{}
 

--- a/azure.go
+++ b/azure.go
@@ -125,7 +125,7 @@ func (ac *AzureClient) getAccessToken() error {
 	return nil
 }
 
-// Return metric definitions for all configured target and resource groups
+// Returns metric definitions for all configured target and resource groups
 func (ac *AzureClient) getMetricDefinitions() (map[string]AzureMetricDefinitionResponse, error) {
 
 	definitions := make(map[string]AzureMetricDefinitionResponse)
@@ -156,7 +156,7 @@ func (ac *AzureClient) getMetricDefinitions() (map[string]AzureMetricDefinitionR
 	return definitions, nil
 }
 
-// Return AzureMetricDefinitionResponse for a given resource
+// Returns AzureMetricDefinitionResponse for a given resource
 func (ac *AzureClient) getAzureMetricDefinitionResponse(resource string) (AzureMetricDefinitionResponse, error) {
 	apiVersion := "2018-01-01"
 
@@ -245,7 +245,7 @@ func (ac *AzureClient) getMetricValue(resource string, metricNames string, aggre
 	return data, nil
 }
 
-// Return resource list resolved and filtered from resource_groups configuration
+// Returns resource list resolved and filtered from resource_groups configuration
 func (ac *AzureClient) filteredListFromResourceGroup(resourceGroup config.ResourceGroup) ([]string, error) {
 	resources, err := ac.listFromResourceGroup(resourceGroup.ResourceGroup, resourceGroup.ResourceTypes)
 	if err != nil {
@@ -255,7 +255,7 @@ func (ac *AzureClient) filteredListFromResourceGroup(resourceGroup config.Resour
 	return filteredResources, nil
 }
 
-// Return all resources for given resource group and types
+// Returns all resources for given resource group and types
 func (ac *AzureClient) listFromResourceGroup(resourceGroup string, resourceTypes []string) ([]string, error) {
 	apiVersion := "2018-02-01"
 
@@ -308,7 +308,7 @@ func (ac *AzureClient) listFromResourceGroup(resourceGroup string, resourceTypes
 	return resources, nil
 }
 
-// Return a filtered resource list based on a given resource list and regular expressions from the configuration
+// Returns a filtered resource list based on a given resource list and regular expressions from the configuration
 func (ac *AzureClient) filterResources(resources []string, resourceGroup config.ResourceGroup) []string {
 	filteredResources := []string{}
 


### PR DESCRIPTION
Hi!
This PR closes #48  .

In order to reuse the resource group filtering logic from the getMetricDefinitions() of AzureClient, this filtering logic has been extracted to new functions in the AzureClient.

Similarly, in order to avoid the duplication of the actual "/metricDefinitions" API call logic, this logic has been extracted to a new function that is called for both targets and resource groups configuration (and soon for tags configuration, see #49 )

Thanks!
