### PR TITLE
Batching requests when querying Azure API

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,8 +126,8 @@ func (c *Collector) batchCollectResources(ch chan<- prometheus.Metric, resources
 			return
 		}
 
-		for i, resp := range batchData.Responses {
-			c.extractMetrics(ch, resources[i], resp.HttpStatusCode, resp.Content)
+		for k, resp := range batchData.Responses {
+			c.extractMetrics(ch, resources[i+k], resp.HttpStatusCode, resp.Content)
 		}
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -31,12 +31,12 @@ func GetTimes() (string, string) {
 // CreateResourceLabels - Returns resource labels for a give resource ID.
 func CreateResourceLabels(resourceID string) map[string]string {
 	labels := make(map[string]string)
-        resource := strings.Split(resourceID, "/")
-        labels["resource_group"] = resource[4]
-        labels["resource_name"] = resource[8]
-        if len(resource) > 13 {
-            labels["sub_resource_name"] = resource[10]
-        }
+	resource := strings.Split(resourceID, "/")
+	labels["resource_group"] = resource[4]
+	labels["resource_name"] = resource[8]
+	if len(resource) > 13 {
+		labels["sub_resource_name"] = resource[10]
+	}
 
 	return labels
 }
@@ -52,4 +52,12 @@ func hasAggregation(aggregations []string, aggregation string) bool {
 		}
 	}
 	return false
+}
+
+func filterAggregations(aggregations []string) []string {
+	base := []string{"Total", "Average", "Minimum", "Maximum"}
+	if len(aggregations) > 0 {
+		return aggregations
+	}
+	return base
 }


### PR DESCRIPTION
This change has been opened in response to issue #19

In order to improve the latency of the exporter I took the original approach from above issue and created a change.
This approach uses the batch endpoint just like Azure Portal. All configured resources are organized into batches and queried one call per batch.