### PR TITLE
Adding type selection to tag filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Name of the tag to be filtered against.
 `resource_tag_value`:
 Value of the tag to be filtered against.
 
-`resource_types`: optional list of types kept in the list of resources gathered by tag. If the list is empty or the parameter is not defined, then all the resources are kept.
+`resource_types`: optional list of types kept in the list of resources gathered by tag. If the list is empty or the parameter is not defined, then all the resources are kept, and configured metric names must exist for every tagged resource.
 
 ## Prometheus configuration
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ resource_tags:
   - resource_tag_name: "group"
     resource_tag_value: "tomonitor"
     resource_types:
-    - "Microsoft.Compute/storage"
+    - "Microsoft.Compute/virtualMachines"
     metrics:
      - name: "CPU Credits Consumed"
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ resource_groups:
 resource_tags:
   - resource_tag_name: "group"
     resource_tag_value: "tomonitor"
+    resource_types:
+     - "Microsoft.Compute/storage"
     metrics:
-    - name: "CPU Credits Consumed"
+     - name: "CPU Credits Consumed"
 
 ```
 
@@ -126,6 +128,8 @@ Name of the tag to be filtered against.
 
 `resource_tag_value`:
 Value of the tag to be filtered against.
+
+`resource_types`: optional list of types kept in the list of resources gathered by tag. If the list is empty or the parameter is not defined, then all the resources are kept.
 
 ## Prometheus configuration
 

--- a/azure-example.yml
+++ b/azure-example.yml
@@ -32,6 +32,6 @@ resource_tags:
   - resource_tag_name: "monitoring"
     resource_tag_value: "enabled"
     resource_types:
-      - "Microsoft.Compute/storage"
+      - "Microsoft.Compute/virtualMachines"
     metrics:
       - name: "CPU Credits consumed"

--- a/azure.go
+++ b/azure.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -250,7 +249,6 @@ func (ac *AzureClient) listFromResourceGroup(resourceGroup string, resourceTypes
 
 // Returns all resource with the given couple tagname, tagvalue
 func (ac *AzureClient) listByTag(tagName string, tagValue string, types []string) ([]string, error) {
-	log.Println("Types ", types)
 	apiVersion := "2018-05-01"
 	securedTagName := secureString(tagName)
 	securedTagValue := secureString(tagValue)
@@ -306,7 +304,6 @@ func getAzureMonitorResponse(azureManagementEndpoint string) ([]byte, error) {
 		return nil, fmt.Errorf("Error creating HTTP request: %v", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+ac.accessToken)
-	log.Printf("Request:%s", req.URL.String())
 	resp, err := ac.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("Error: %v", err)

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // Config - Azure exporter configuration

--- a/config/config.go
+++ b/config/config.go
@@ -7,17 +7,17 @@ import (
 	"strings"
 	"sync"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Config - Azure exporter configuration
 type Config struct {
-	ActiveDirectoryAuthorityURL      string          `yaml:"active_directory_authority_url"`
-	ResourceManagerURL               string          `yaml:"resource_manager_url"`
-	Credentials    Credentials     `yaml:"credentials"`
-	Targets        []Target        `yaml:"targets"`
-	ResourceGroups []ResourceGroup `yaml:"resource_groups"`
-	ResourceTags   []ResourceTag   `yaml:"resource_tags"`
+	ActiveDirectoryAuthorityURL string          `yaml:"active_directory_authority_url"`
+	ResourceManagerURL          string          `yaml:"resource_manager_url"`
+	Credentials                 Credentials     `yaml:"credentials"`
+	Targets                     []Target        `yaml:"targets"`
+	ResourceGroups              []ResourceGroup `yaml:"resource_groups"`
+	ResourceTags                []ResourceTag   `yaml:"resource_tags"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`
@@ -33,7 +33,7 @@ type SafeConfig struct {
 func (sc *SafeConfig) ReloadConfig(confFile string) (err error) {
 	var c = &Config{
 		ActiveDirectoryAuthorityURL: "https://login.microsoftonline.com/",
-		ResourceManagerURL: "https://management.azure.com/",
+		ResourceManagerURL:          "https://management.azure.com/",
 	}
 
 	yamlFile, err := ioutil.ReadFile(confFile)
@@ -150,6 +150,7 @@ type ResourceGroup struct {
 type ResourceTag struct {
 	ResourceTagName  string   `yaml:"resource_tag_name"`
 	ResourceTagValue string   `yaml:"resource_tag_value"`
+	ResourceTypes    []string `yaml:"resource_types"`
 	Metrics          []Metric `yaml:"metrics"`
 	Aggregations     []string `yaml:"aggregations"`
 


### PR DESCRIPTION
With the tag filtering feature, we had no option to deal with metrics that were not existing for one type of the tagged resources. The problem being that if resources of different types are tagged with the same key/value, metric collection would fail.
With type filtering we can add filters for tags and specific types so that requests of metrics that do not exist for a specific tagged resource do not affect retrieving the other metrics of the resource.