### PR TITLE
Reducing Azure API calls for tagged resources 

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -332,17 +332,18 @@ func (ac *AzureClient) listByTag(tagName string, tagValue string, types []string
 	subscription := fmt.Sprintf("subscriptions/%s", sc.C.Credentials.SubscriptionID)
 	resourcesEndpoint := fmt.Sprintf("%s/%s/resources?api-version=%s&$filter=%s", sc.C.ResourceManagerURL, subscription, apiVersion, filterTypes)
 
-	body, dataExists := resourcesMap[resourcesEndpoint]
-	data := AzureResourceListResponse{}
-	var err error
-	if !dataExists {
+	body, ok := resourcesMap[resourcesEndpoint]
+	if !ok {
+		var err error
 		body, err = getAzureMonitorResponse(resourcesEndpoint)
 		if err != nil {
 			return nil, err
 		}
 		resourcesMap[resourcesEndpoint] = body
 	}
-	err = json.Unmarshal(body, &data)
+
+	var data AzureResourceListResponse
+	err := json.Unmarshal(body, &data)
 	if err != nil {
 		return nil, fmt.Errorf("Error unmarshalling response body: %v", err)
 	}

--- a/azure.go
+++ b/azure.go
@@ -290,8 +290,8 @@ func (ac *AzureClient) filteredListFromResourceGroup(resourceGroup config.Resour
 }
 
 // Returns resource list filtered by tag name and tag value
-func (ac *AzureClient) filteredListByTag(resourceTag config.ResourceTag) ([]AzureResource, error) {
-	resources, err := ac.listByTag(resourceTag.ResourceTagName, resourceTag.ResourceTagValue, resourceTag.ResourceTypes)
+func (ac *AzureClient) filteredListByTag(resourceTag config.ResourceTag, resourcesMap map[string][]byte) ([]AzureResource, error) {
+	resources, err := ac.listByTag(resourceTag.ResourceTagName, resourceTag.ResourceTagValue, resourceTag.ResourceTypes, resourcesMap)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +324,7 @@ func (ac *AzureClient) listFromResourceGroup(resourceGroup string, resourceTypes
 }
 
 // Returns all resource with the given couple tagname, tagvalue
-func (ac *AzureClient) listByTag(tagName string, tagValue string, types []string) ([]AzureResource, error) {
+func (ac *AzureClient) listByTag(tagName string, tagValue string, types []string, resourcesMap map[string][]byte) ([]AzureResource, error) {
 	apiVersion := "2018-05-01"
 	securedTagName := secureString(tagName)
 	securedTagValue := secureString(tagValue)
@@ -332,12 +332,16 @@ func (ac *AzureClient) listByTag(tagName string, tagValue string, types []string
 	subscription := fmt.Sprintf("subscriptions/%s", sc.C.Credentials.SubscriptionID)
 	resourcesEndpoint := fmt.Sprintf("%s/%s/resources?api-version=%s&$filter=%s", sc.C.ResourceManagerURL, subscription, apiVersion, filterTypes)
 
-	body, err := getAzureMonitorResponse(resourcesEndpoint)
-	if err != nil {
-		return nil, err
+	body, dataExists := resourcesMap[resourcesEndpoint]
+	data := AzureResourceListResponse{}
+	var err error
+	if !dataExists {
+		body, err = getAzureMonitorResponse(resourcesEndpoint)
+		if err != nil {
+			return nil, err
+		}
+		resourcesMap[resourcesEndpoint] = body
 	}
-
-	var data AzureResourceListResponse
 	err = json.Unmarshal(body, &data)
 	if err != nil {
 		return nil, fmt.Errorf("Error unmarshalling response body: %v", err)

--- a/main.go
+++ b/main.go
@@ -258,6 +258,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		}
 	}
 
+	resourcesCache := make(map[string][]byte)
 	for _, resourceTag := range sc.C.ResourceTags {
 		metrics := []string{}
 		for _, metric := range resourceTag.Metrics {
@@ -265,7 +266,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		}
 		metricsStr := strings.Join(metrics, ",")
 
-		filteredResources, err := ac.filteredListByTag(resourceTag)
+		filteredResources, err := ac.filteredListByTag(resourceTag, resourcesCache)
 		if err != nil {
 			log.Printf("Failed to get resources for tag name %s, tag value %s: %v",
 				resourceTag.ResourceTagName, resourceTag.ResourceTagValue, err)


### PR DESCRIPTION
The tagged resource feature uses types to filter the metrics gathered correctly. The implementation was making several same call to the Azure API. I added a simple map to cache the result of the calls made for a tagName and tagValue to limit the number of unneeded calls made to the API.