### PR TITLE
Prefix for tag based labels

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -43,12 +43,12 @@ func GetTimes() (string, string) {
 func CreateResourceLabels(resourceURL string) map[string]string {
 	labels := make(map[string]string)
 	resource := strings.Split(resourceURL, "/")
+
 	labels["resource_group"] = resource[resourceGroupPosition]
 	labels["resource_name"] = resource[resourceNamePosition]
 	if len(resource) > 13 {
 		labels["sub_resource_name"] = resource[subResourceNamePosition]
 	}
-
 	return labels
 }
 

--- a/utils.go
+++ b/utils.go
@@ -16,8 +16,7 @@ var (
 	resourceNamePosition    = 8
 	subResourceNamePosition = 10
 
-	invalidLabelPrefix = regexp.MustCompile(`^[^a-zA-Z_]*`)
-	invalidLabelChars  = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
+	invalidLabelChars = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
 )
 
 // PrintPrettyJSON - Prints structs nicely for debugging.
@@ -66,11 +65,7 @@ func CreateAllResourceLabelsFrom(rm resourceMeta) map[string]string {
 
 	for k, v := range rm.resource.Tags {
 		k = strings.ToLower(k)
-
-		if !invalidLabelPrefix.MatchString(k) {
-			k = "_" + k
-		}
-
+		k = "tag_" + k
 		k = invalidLabelChars.ReplaceAllString(k, "_")
 		labels[k] = v
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCreateResourceLabels(t *testing.T) {
+	var cases = []struct {
+		url  string
+		want map[string]string
+	}{
+		{
+			"/subscriptions/abc123d4-e5f6-g7h8-i9j10-a1b2c3d4e5f6/resourceGroups/prod-rg-001/providers/Microsoft.Compute/virtualMachines/prod-vm-01/providers/microsoft.insights/metrics",
+			map[string]string{"resource_group": "prod-rg-001", "resource_name": "prod-vm-01"},
+		},
+		{
+			"/subscriptions/abc123d4-e5f6-g7h8-i9j10-a1b2c3d4e5f6/resourceGroups/prod-rg-002/providers/Microsoft.Sql/servers/sqlprod/databases/prod-db-01/providers/microsoft.insights/metrics",
+			map[string]string{"resource_group": "prod-rg-002", "resource_name": "sqlprod", "sub_resource_name": "prod-db-01"},
+		},
+	}
+
+	for _, c := range cases {
+		got := CreateResourceLabels(c.url)
+
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("doesn't create expected resource labels\ngot: %v\nwant: %v", got, c.want)
+		}
+	}
+}
+
+func TestCreateAllResourceLabelsFrom(t *testing.T) {
+	var cases = []struct {
+		rm   resourceMeta
+		want map[string]string
+	}{
+		{
+			resourceMeta{
+				resourceURL: "/subscriptions/abc123d4-e5f6-g7h8-i9j10-a1b2c3d4e5f6/resourceGroups/prod-rg-001/providers/Microsoft.Compute/virtualMachines/prod-vm-01/providers/microsoft.insights/metrics",
+				resource: AzureResource{
+					ID:           "/resourceGroups/prod-rg-001/providers/Microsoft.Compute/virtualMachines/prod-vm-01",
+					Name:         "fxpromdev01",
+					Location:     "canadaeast",
+					Type:         "Microsoft.Compute/virtualMachines",
+					Tags:         map[string]string{"monitoring": "enabled", "department": "secret"},
+					Subscription: "abc123d4-e5f6-g7h8-i9j10-a1b2c3d4e5f6",
+				},
+			},
+			map[string]string{
+				"azure_location":     "canadaeast",
+				"azure_subscription": "abc123d4-e5f6-g7h8-i9j10-a1b2c3d4e5f6",
+				"id":                 "/resourceGroups/prod-rg-001/providers/Microsoft.Compute/virtualMachines/prod-vm-01",
+				"managed_by":         "",
+				"resource_group":     "prod-rg-001",
+				"resource_name":      "prod-vm-01",
+				"resource_type":      "Microsoft.Compute/virtualMachines",
+				"tag_department":     "secret",
+				"tag_monitoring":     "enabled",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		got := CreateAllResourceLabelsFrom(c.rm)
+
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("doesn't create expected resource labels\ngot: %v\nwant: %v", got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
This change is a follow up to #66 and introduces two fixes.

1. @brian-brazil as you pointed out during the review of that change, it is important to differentiate 
between meta-data coming from Azure Monitor and tags defined by our users, as they can clash.
My recommendation was to prefix tags in order to do so, however this change never made it to the final PR. I am proposing this PR to introduce these prefixes.
Also, I went ahead and removed the invalid label prefix check as that has become obsolete with current change.

2. We are generating the `resource_name` label from `AzureResource.Name`. This can cause inconsistency when we try to map metrics against `azure_resource_info`, as certain resource types contain a sub resource name that is used in `resource_name`. To overcome this limitation this change proposes to overwrite the `resource_name` label the same way we do for all the other metrics. 