### PR TITLE
Added delay option to retrieve the metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ resource_tags:
       - "Microsoft.Compute/virtualMachines"
     metrics:
       - name: "CPU Credits Consumed"
-    timespan: 10
+    delay_minutes: 10
 ```
 
 By default, all aggregations are returned (`Total`, `Maximum`, `Average`, `Minimum`). It can be overridden per resource.

--- a/README.md
+++ b/README.md
@@ -136,11 +136,9 @@ Value of the tag to be filtered against.
 
 `resource_types`: optional list of types kept in the list of resources gathered by tag. If none are specified, then all the resources are kept. All defined metrics must exist for each processed resource.
 
-### Timespan override
-To get the values of the metrics, the exporter uses a default timeframe starting 3 minutes before the time
-of the request and 2 minutes. Some metrics that are not yet gathered will carry 0 values that are not relevant
-on some cases. To avoid this you can use the `timespan` option that takes a number of minutes from the time of the 
-request to start the timeframe.
+### Metrics delay override
+You can override the delay used to retrieve the newest data. It is used to avoid collecting data that has not fully
+converged. Defaults to 3 minutes.
 
 ## Prometheus configuration
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ resource_tags:
       - "Microsoft.Compute/virtualMachines"
     metrics:
       - name: "CPU Credits Consumed"
-
+    timespan: 10
 ```
 
 By default, all aggregations are returned (`Total`, `Maximum`, `Average`, `Minimum`). It can be overridden per resource.
@@ -135,6 +135,12 @@ Name of the tag to be filtered against.
 Value of the tag to be filtered against.
 
 `resource_types`: optional list of types kept in the list of resources gathered by tag. If none are specified, then all the resources are kept. All defined metrics must exist for each processed resource.
+
+### Timespan override
+To get the values of the metrics, the exporter uses a default timeframe starting 3 minutes before the time
+of the request and 2 minutes. Some metrics that are not yet gathered will carry 0 values that are not relevant
+on some cases. To avoid this you can use the `timespan` option that takes a number of minutes from the time of the 
+request to start the timeframe.
 
 ## Prometheus configuration
 

--- a/azure-example.yml
+++ b/azure-example.yml
@@ -35,4 +35,4 @@ resource_tags:
       - "Microsoft.Compute/virtualMachines"
     metrics:
       - name: "CPU Credits consumed"
-    timespan: 10
+    delay_minutes: 10

--- a/azure-example.yml
+++ b/azure-example.yml
@@ -35,3 +35,4 @@ resource_tags:
       - "Microsoft.Compute/virtualMachines"
     metrics:
       - name: "CPU Credits consumed"
+    timespan: 10

--- a/azure.go
+++ b/azure.go
@@ -515,7 +515,7 @@ func resourceURLFrom(resource string, metricNames string, aggregations []string,
 	}
 	filtered := filterAggregations(aggregations)
 	values.Add("aggregation", strings.Join(filtered, ","))
-	values.Add("delay", fmt.Sprintf("%s/%s", startTime, endTime))
+	values.Add("timespan", fmt.Sprintf("%s/%s", startTime, endTime))
 	values.Add("api-version", apiVersion)
 
 	url := url.URL{

--- a/azure.go
+++ b/azure.go
@@ -498,7 +498,7 @@ type batchRequest struct {
 	Method      string `json:"httpMethod"`
 }
 
-func resourceURLFrom(resource string, metricNames string, aggregations []string) string {
+func resourceURLFrom(resource string, metricNames string, aggregations []string, timespan int) string {
 	apiVersion := "2018-01-01"
 
 	path := fmt.Sprintf(
@@ -507,7 +507,7 @@ func resourceURLFrom(resource string, metricNames string, aggregations []string)
 		resource,
 	)
 
-	endTime, startTime := GetTimes()
+	endTime, startTime := GetTimes(timespan)
 
 	values := url.Values{}
 	if metricNames != "" {

--- a/azure.go
+++ b/azure.go
@@ -498,7 +498,7 @@ type batchRequest struct {
 	Method      string `json:"httpMethod"`
 }
 
-func resourceURLFrom(resource string, metricNames string, aggregations []string, timespan int) string {
+func resourceURLFrom(resource string, metricNames string, aggregations []string, delay int) string {
 	apiVersion := "2018-01-01"
 
 	path := fmt.Sprintf(
@@ -507,7 +507,7 @@ func resourceURLFrom(resource string, metricNames string, aggregations []string,
 		resource,
 	)
 
-	endTime, startTime := GetTimes(timespan)
+	endTime, startTime := GetTimes(delay)
 
 	values := url.Values{}
 	if metricNames != "" {
@@ -515,7 +515,7 @@ func resourceURLFrom(resource string, metricNames string, aggregations []string,
 	}
 	filtered := filterAggregations(aggregations)
 	values.Add("aggregation", strings.Join(filtered, ","))
-	values.Add("timespan", fmt.Sprintf("%s/%s", startTime, endTime))
+	values.Add("delay", fmt.Sprintf("%s/%s", startTime, endTime))
 	values.Add("api-version", apiVersion)
 
 	url := url.URL{

--- a/config/config.go
+++ b/config/config.go
@@ -127,9 +127,10 @@ type Credentials struct {
 
 // Target represents Azure target resource and its associated metric definitions
 type Target struct {
-	Resource     string   `yaml:"resource"`
-	Metrics      []Metric `yaml:"metrics"`
-	Aggregations []string `yaml:"aggregations"`
+	Resource      string   `yaml:"resource"`
+	Metrics       []Metric `yaml:"metrics"`
+	Aggregations  []string `yaml:"aggregations"`
+	TimespanBegin int      `yaml:"timespan"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }
@@ -142,6 +143,7 @@ type ResourceGroup struct {
 	ResourceNameExcludeRe []Regexp `yaml:"resource_name_exclude_re"`
 	Metrics               []Metric `yaml:"metrics"`
 	Aggregations          []string `yaml:"aggregations"`
+	TimespanBegin         int      `yaml:"timespan"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }
@@ -153,6 +155,7 @@ type ResourceTag struct {
 	ResourceTypes    []string `yaml:"resource_types"`
 	Metrics          []Metric `yaml:"metrics"`
 	Aggregations     []string `yaml:"aggregations"`
+	TimespanBegin    int      `yaml:"timespan"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -127,10 +127,10 @@ type Credentials struct {
 
 // Target represents Azure target resource and its associated metric definitions
 type Target struct {
-	Resource      string   `yaml:"resource"`
-	Metrics       []Metric `yaml:"metrics"`
-	Aggregations  []string `yaml:"aggregations"`
-	TimespanBegin int      `yaml:"delay_minutes"`
+	Resource     string   `yaml:"resource"`
+	Metrics      []Metric `yaml:"metrics"`
+	Aggregations []string `yaml:"aggregations"`
+	DelayMinutes int      `yaml:"delay_minutes"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }
@@ -143,7 +143,7 @@ type ResourceGroup struct {
 	ResourceNameExcludeRe []Regexp `yaml:"resource_name_exclude_re"`
 	Metrics               []Metric `yaml:"metrics"`
 	Aggregations          []string `yaml:"aggregations"`
-	TimespanBegin         int      `yaml:"delay_minutes"`
+	DelayMinutes          int      `yaml:"delay_minutes"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }
@@ -155,7 +155,7 @@ type ResourceTag struct {
 	ResourceTypes    []string `yaml:"resource_types"`
 	Metrics          []Metric `yaml:"metrics"`
 	Aggregations     []string `yaml:"aggregations"`
-	TimespanBegin    int      `yaml:"delay_minutes"`
+	DelayMinutes     int      `yaml:"delay_minutes"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -130,7 +130,7 @@ type Target struct {
 	Resource      string   `yaml:"resource"`
 	Metrics       []Metric `yaml:"metrics"`
 	Aggregations  []string `yaml:"aggregations"`
-	TimespanBegin int      `yaml:"timespan"`
+	TimespanBegin int      `yaml:"delay_minutes"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }
@@ -143,7 +143,7 @@ type ResourceGroup struct {
 	ResourceNameExcludeRe []Regexp `yaml:"resource_name_exclude_re"`
 	Metrics               []Metric `yaml:"metrics"`
 	Aggregations          []string `yaml:"aggregations"`
-	TimespanBegin         int      `yaml:"timespan"`
+	TimespanBegin         int      `yaml:"delay_minutes"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }
@@ -155,7 +155,7 @@ type ResourceTag struct {
 	ResourceTypes    []string `yaml:"resource_types"`
 	Metrics          []Metric `yaml:"metrics"`
 	Aggregations     []string `yaml:"aggregations"`
-	TimespanBegin    int      `yaml:"timespan"`
+	TimespanBegin    int      `yaml:"delay_minutes"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/main.go
+++ b/main.go
@@ -228,7 +228,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		rm.resourceID = target.Resource
 		rm.metrics = strings.Join(metrics, ",")
 		rm.aggregations = filterAggregations(target.Aggregations)
-		rm.resourceURL = resourceURLFrom(target.Resource, rm.metrics, rm.aggregations, target.TimespanBegin)
+		rm.resourceURL = resourceURLFrom(target.Resource, rm.metrics, rm.aggregations, target.DelayMinutes)
 		incompleteResources = append(incompleteResources, rm)
 	}
 
@@ -252,7 +252,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			rm.resourceID = f.ID
 			rm.metrics = metricsStr
 			rm.aggregations = filterAggregations(resourceGroup.Aggregations)
-			rm.resourceURL = resourceURLFrom(f.ID, rm.metrics, rm.aggregations, resourceGroup.TimespanBegin)
+			rm.resourceURL = resourceURLFrom(f.ID, rm.metrics, rm.aggregations, resourceGroup.DelayMinutes)
 			rm.resource = f
 			resources = append(resources, rm)
 		}
@@ -279,7 +279,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			rm.resourceID = f.ID
 			rm.metrics = metricsStr
 			rm.aggregations = filterAggregations(resourceTag.Aggregations)
-			rm.resourceURL = resourceURLFrom(f.ID, rm.metrics, rm.aggregations, resourceTag.TimespanBegin)
+			rm.resourceURL = resourceURLFrom(f.ID, rm.metrics, rm.aggregations, resourceTag.DelayMinutes)
 			incompleteResources = append(incompleteResources, rm)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -228,7 +228,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		rm.resourceID = target.Resource
 		rm.metrics = strings.Join(metrics, ",")
 		rm.aggregations = filterAggregations(target.Aggregations)
-		rm.resourceURL = resourceURLFrom(target.Resource, rm.metrics, rm.aggregations)
+		rm.resourceURL = resourceURLFrom(target.Resource, rm.metrics, rm.aggregations, target.TimespanBegin)
 		incompleteResources = append(incompleteResources, rm)
 	}
 
@@ -252,7 +252,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			rm.resourceID = f.ID
 			rm.metrics = metricsStr
 			rm.aggregations = filterAggregations(resourceGroup.Aggregations)
-			rm.resourceURL = resourceURLFrom(f.ID, rm.metrics, rm.aggregations)
+			rm.resourceURL = resourceURLFrom(f.ID, rm.metrics, rm.aggregations, resourceGroup.TimespanBegin)
 			rm.resource = f
 			resources = append(resources, rm)
 		}
@@ -279,7 +279,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			rm.resourceID = f.ID
 			rm.metrics = metricsStr
 			rm.aggregations = filterAggregations(resourceTag.Aggregations)
-			rm.resourceURL = resourceURLFrom(f.ID, rm.metrics, rm.aggregations)
+			rm.resourceURL = resourceURLFrom(f.ID, rm.metrics, rm.aggregations, resourceTag.TimespanBegin)
 			incompleteResources = append(incompleteResources, rm)
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/main_test.go
+++ b/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/utils.go
+++ b/utils.go
@@ -28,14 +28,20 @@ func PrintPrettyJSON(input map[string]interface{}) {
 	fmt.Println(string(out))
 }
 
+const TimespanDefault = 3
+
 // GetTimes - Returns the endTime and startTime used for querying Azure Metrics API
-func GetTimes() (string, string) {
+// set timespan to 0 to use the default
+func GetTimes(timespan int) (string, string) {
 	// Make sure we are using UTC
 	now := time.Now().UTC()
 
-	// Use query delay of 3 minutes when querying for latest metric data
-	endTime := now.Add(time.Minute * time.Duration(-3)).Format(time.RFC3339)
-	startTime := now.Add(time.Minute * time.Duration(-4)).Format(time.RFC3339)
+	if timespan == 0 {
+		timespan = TimespanDefault
+	}
+	// Use query delay of 3 minutes by default or use the timespan passed when querying for latest metric data
+	endTime := now.Add(time.Minute * time.Duration(-timespan+1)).Format(time.RFC3339)
+	startTime := now.Add(time.Minute * time.Duration(-timespan)).Format(time.RFC3339)
 	return endTime, startTime
 }
 

--- a/utils.go
+++ b/utils.go
@@ -28,20 +28,20 @@ func PrintPrettyJSON(input map[string]interface{}) {
 	fmt.Println(string(out))
 }
 
-const TimespanDefault = 3
+const DefaultDelay = 3
 
 // GetTimes - Returns the endTime and startTime used for querying Azure Metrics API
-// set timespan to 0 to use the default
-func GetTimes(timespan int) (string, string) {
+// set delay to 0 to use the default
+func GetTimes(delay int) (string, string) {
 	// Make sure we are using UTC
 	now := time.Now().UTC()
 
-	if timespan == 0 {
-		timespan = TimespanDefault
+	if delay == 0 {
+		delay = DefaultDelay
 	}
-	// Use query delay of 3 minutes by default or use the timespan passed when querying for latest metric data
-	endTime := now.Add(time.Minute * time.Duration(-timespan+1)).Format(time.RFC3339)
-	startTime := now.Add(time.Minute * time.Duration(-timespan)).Format(time.RFC3339)
+	// Use query delay of 3 minutes by default or use the delay passed when querying for latest metric data
+	endTime := now.Add(time.Minute * time.Duration(-delay+1)).Format(time.RFC3339)
+	startTime := now.Add(time.Minute * time.Duration(-delay)).Format(time.RFC3339)
 	return endTime, startTime
 }
 


### PR DESCRIPTION
It is used to avoid collecting data that has not fully converged.
For target, group and tag configuration, we can set the delay_minutes parameter to specify more than the 3 default minutes.