### PR TITLE
Fix a bug about comparing types to get apiVersions

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -17,8 +17,7 @@ import (
 )
 
 var (
-	apiVersionDate     = regexp.MustCompile("^\\d{4}-\\d{2}-\\d{2}")
-	targetResourceType = regexp.MustCompile("[mM]icrosoft\\.[a-zA-Z]+(\\/[a-zA-Z]+)")
+	apiVersionDate = regexp.MustCompile("^\\d{4}-\\d{2}-\\d{2}")
 )
 
 // AzureMetricDefinitionResponse represents metric definition response for a given resource from Azure.

--- a/main.go
+++ b/main.go
@@ -171,7 +171,7 @@ func (c *Collector) batchLookupResources(resources []resourceMeta) ([]resourceMe
 
 		var urls []string
 		for _, r := range resources[i:j] {
-			resourceType := targetResourceType.FindString(r.resourceID)
+			resourceType := GetResourceType(r.resourceURL)
 			if resourceType == "" {
 				return nil, fmt.Errorf("No type found for resource: %s", r.resourceID)
 			}

--- a/utils.go
+++ b/utils.go
@@ -12,11 +12,13 @@ import (
 
 var (
 	// resource component positions in a ResourceURL
-	resourceGroupPosition   = 4
-	resourceNamePosition    = 8
-	subResourceNamePosition = 10
-
-	invalidLabelChars = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
+	resourceGroupPosition      = 4
+	resourceNamePosition       = 8
+	subResourceNamePosition    = 10
+	resourceTypeSuffixPosition = 9
+	resourceTypePosition       = 7
+	resourceTypePrefixPosition = 6
+	invalidLabelChars          = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
 )
 
 // PrintPrettyJSON - Prints structs nicely for debugging.
@@ -50,6 +52,20 @@ func CreateResourceLabels(resourceURL string) map[string]string {
 		labels["sub_resource_name"] = resource[subResourceNamePosition]
 	}
 	return labels
+}
+
+// GetResourceType returns the resource type with the namespace
+func GetResourceType(resourceURL string) string {
+	resource := strings.Split(resourceURL, "/")
+	var str strings.Builder
+	str.WriteString(resource[resourceTypePrefixPosition])
+	str.WriteString("/")
+	str.WriteString(resource[resourceTypePosition])
+	if len(resource) > 13 {
+		str.WriteString("/")
+		str.WriteString(resource[resourceTypeSuffixPosition])
+	}
+	return str.String()
 }
 
 func CreateAllResourceLabelsFrom(rm resourceMeta) map[string]string {

--- a/utils_test.go
+++ b/utils_test.go
@@ -68,3 +68,27 @@ func TestCreateAllResourceLabelsFrom(t *testing.T) {
 		}
 	}
 }
+
+func TestCetResourceType(t *testing.T) {
+	var cases = []struct {
+		url  string
+		want string
+	}{
+		{
+			"/subscriptions/abc123d4-e5f6-g7h8-i9j10-a1b2c3d4e5f6/resourceGroups/prod-rg-001/providers/Microsoft.Compute/virtualMachines/prod-vm-01/providers/microsoft.insights/metrics",
+			"Microsoft.Compute/virtualMachines",
+		},
+		{
+			"/subscriptions/abc123d4-e5f6-g7h8-i9j10-a1b2c3d4e5f6/resourceGroups/prod-rg-002/providers/Microsoft.Sql/servers/sqlprod/databases/prod-db-01/providers/microsoft.insights/metrics",
+			"Microsoft.Sql/servers/databases",
+		},
+	}
+
+	for _, c := range cases {
+		got := GetResourceType(c.url)
+
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("doesn't create expected resource type\ngot: %v\nwant: %v", got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
To get the apiVersion to use to be able to get the azure_resource_info, the resources that have a sub resource were not taken into account.
I used the same decomposition method than the one used to create the labels and added a unit test.