### PR TITLE
Support Azure Monitor custom metric namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,26 +19,6 @@ go get -u github.com/RobustPerception/azure_metrics_exporter
 
 Note that Azure imposes an [API read limit of 15,000 requests per hour](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-request-limits) so the number of metrics you're querying for should be proportional to your scrape interval.
 
-## Retrieving Metric definitions
-
-In order to get all the metric definitions for the resources specified in your configuration file, run the following:
-
-```bash
-./azure-metrics-exporter --list.definitions
-```
-
-This will print your resource id's application/service name along with a list of each of the available metric definitions that you can query for for that resource.
-
-## Retrieving Metric namespaces
-
-In order to get all the metric namespaces for the resources specified in your configuration file, run the following:
-
-```bash
-./azure-metrics-exporter --list.namespaces
-```
-
-This will print your resource id's application/service name along with a list of each of the available metric namespaces that you can query for for that resource.
-
 ## Exporter configuration
 
 This exporter requires a configuration file. By default, it will look for the azure.yml file in the CWD.
@@ -152,6 +132,26 @@ Name of the tag to be filtered against.
 Value of the tag to be filtered against.
 
 `resource_types`: optional list of types kept in the list of resources gathered by tag. If none are specified, then all the resources are kept. All defined metrics must exist for each processed resource.
+
+### Retrieving Metric definitions
+
+In order to get all the metric definitions for the resources specified in your configuration file, run the following:
+
+```bash
+./azure-metrics-exporter --list.definitions
+```
+
+This will print your resource id's application/service name along with a list of each of the available metric definitions that you can query for for that resource.
+
+### Retrieving Metric namespaces
+
+In order to get all the metric namespaces for the resources specified in your configuration file, run the following:
+
+```bash
+./azure-metrics-exporter --list.namespaces
+```
+
+This will print your resource id's application/service name along with a list of each of the available metric namespaces that you can query for for that resource.
 
 ## Prometheus configuration
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ resource_tags:
 By default, all aggregations are returned (`Total`, `Maximum`, `Average`, `Minimum`). It can be overridden per resource.
 
 The `metric_namespace` property is optional for all filtering types.
+When the metric namepace is specified, it will be added as a prefix of the metric name.
 It can be used to target [custom metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview), such as [guest OS performance counters](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/collect-custom-metrics-guestos-vm-classic).
 If not specified, the default metric namespace of the resource will apply.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ targets:
     metrics:
     - name: "Http2xx"
     - name: "Http5xx"
+  - resource: "azure_resource_id"
+    metric_namespace: "Azure.VM.Windows.GuestMetrics"
+    metrics:
+    - name: 'Process\Thread Count'
 
 resource_groups:
   - resource_group: "webapps"
@@ -117,6 +121,9 @@ resource_tags:
 
 By default, all aggregations are returned (`Total`, `Maximum`, `Average`, `Minimum`). It can be overridden per resource.
 
+The `metric_namespace` property is optional for all filtering types.
+It can be used to target custom metrics, such as [guest OS performance counters](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/collect-custom-metrics-guestos-vm-classic).
+If not specified, the default metric namespace of the resource will apply.
 
 ### Resource group filtering
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ In order to get all the metric definitions for the resources specified in your c
 
 This will print your resource id's application/service name along with a list of each of the available metric definitions that you can query for for that resource.
 
+## Retrieving Metric namespaces
+
+In order to get all the metric namespaces for the resources specified in your configuration file, run the following:
+
+```bash
+./azure-metrics-exporter --list.namespaces
+```
+
+This will print your resource id's application/service name along with a list of each of the available metric namespaces that you can query for for that resource.
+
 ## Exporter configuration
 
 This exporter requires a configuration file. By default, it will look for the azure.yml file in the CWD.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ resource_tags:
 By default, all aggregations are returned (`Total`, `Maximum`, `Average`, `Minimum`). It can be overridden per resource.
 
 The `metric_namespace` property is optional for all filtering types.
-When the metric namepace is specified, it will be added as a prefix of the metric name.
+When the metric namespace is specified, it will be added as a prefix of the metric name.
 It can be used to target [custom metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview), such as [guest OS performance counters](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/collect-custom-metrics-guestos-vm-classic).
 If not specified, the default metric namespace of the resource will apply.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ resource_tags:
 By default, all aggregations are returned (`Total`, `Maximum`, `Average`, `Minimum`). It can be overridden per resource.
 
 The `metric_namespace` property is optional for all filtering types.
-It can be used to target custom metrics, such as [guest OS performance counters](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/collect-custom-metrics-guestos-vm-classic).
+It can be used to target [custom metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview), such as [guest OS performance counters](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/collect-custom-metrics-guestos-vm-classic).
 If not specified, the default metric namespace of the resource will apply.
 
 ### Resource group filtering

--- a/azure-example.yml
+++ b/azure-example.yml
@@ -16,6 +16,10 @@ targets:
     metrics:
       - name: "Http2xx"
       - name: "Http5xx"
+  - resource: "/resourceGroups/vm-group/providers/Microsoft.Compute/virtualMachines/my-vm-with-diagnostic"
+    metric_namespace: "Azure.VM.Windows.GuestMetrics"
+    metrics:
+    - name: 'Process\Thread Count'
 
 resource_groups:
   - resource_group: "webapps"

--- a/azure-example.yml
+++ b/azure-example.yml
@@ -16,7 +16,7 @@ targets:
     metrics:
       - name: "Http2xx"
       - name: "Http5xx"
-  - resource: "/resourceGroups/vm-group/providers/Microsoft.Compute/virtualMachines/my-vm-with-diagnostic"
+  - resource: "/resourceGroups/vm-group/providers/Microsoft.Compute/virtualMachines/vm"
     metric_namespace: "Azure.VM.Windows.GuestMetrics"
     metrics:
     - name: 'Process\Thread Count'

--- a/azure.go
+++ b/azure.go
@@ -316,7 +316,7 @@ func (ac *AzureClient) getAzureMetricDefinitionResponse(resource string, metricN
 
 	metricsResource := fmt.Sprintf("subscriptions/%s%s", sc.C.Credentials.SubscriptionID, resource)
 	metricsTarget := fmt.Sprintf("%s/%s/providers/microsoft.insights/metricDefinitions?api-version=%s", sc.C.ResourceManagerURL, metricsResource, apiVersion)
-	if len(metricNamespace) > 0 {
+	if metricNamespace != "" {
 		metricsTarget = fmt.Sprintf("%s&metricnamespace=%s", metricsTarget, metricNamespace)
 	}
 

--- a/azure.go
+++ b/azure.go
@@ -317,7 +317,7 @@ func (ac *AzureClient) getAzureMetricDefinitionResponse(resource string, metricN
 	metricsResource := fmt.Sprintf("subscriptions/%s%s", sc.C.Credentials.SubscriptionID, resource)
 	metricsTarget := fmt.Sprintf("%s/%s/providers/microsoft.insights/metricDefinitions?api-version=%s", sc.C.ResourceManagerURL, metricsResource, apiVersion)
 	if metricNamespace != "" {
-		metricsTarget = fmt.Sprintf("%s&metricnamespace=%s", metricsTarget, metricNamespace)
+		metricsTarget = fmt.Sprintf("%s&metricnamespace=%s", metricsTarget, url.QueryEscape(metricNamespace))
 	}
 
 	req, err := http.NewRequest("GET", metricsTarget, nil)

--- a/azure.go
+++ b/azure.go
@@ -282,7 +282,7 @@ func (ac *AzureClient) getMetricDefinitions() (map[string]AzureMetricDefinitionR
 	return definitions, nil
 }
 
-// Returns metric namespaces for all configured target and resource groups
+// Returns metric namespaces for all configured target and resource groups.
 func (ac *AzureClient) getMetricNamespaces() (map[string]MetricNamespaceCollectionResponse, error) {
 	namespaces := make(map[string]MetricNamespaceCollectionResponse)
 	for _, target := range sc.C.Targets {

--- a/azure.go
+++ b/azure.go
@@ -286,11 +286,11 @@ func (ac *AzureClient) getMetricDefinitions() (map[string]AzureMetricDefinitionR
 func (ac *AzureClient) getMetricNamespaces() (map[string]MetricNamespaceCollectionResponse, error) {
 	namespaces := make(map[string]MetricNamespaceCollectionResponse)
 	for _, target := range sc.C.Targets {
-		namespace, err := ac.getMetricNamespaceCollectionResponse(target.Resource)
+		namespaceCollection, err := ac.getMetricNamespaceCollectionResponse(target.Resource)
 		if err != nil {
 			return nil, err
 		}
-		namespaces[target.Resource] = *namespace
+		namespaces[target.Resource] = *namespaceCollection
 	}
 
 	for _, resourceGroup := range sc.C.ResourceGroups {
@@ -300,11 +300,11 @@ func (ac *AzureClient) getMetricNamespaces() (map[string]MetricNamespaceCollecti
 				resourceGroup.ResourceGroup, resourceGroup.ResourceTypes, err)
 		}
 		for _, resource := range resources {
-			namespace, err := ac.getMetricNamespaceCollectionResponse(resource.ID)
+			namespaceCollection, err := ac.getMetricNamespaceCollectionResponse(resource.ID)
 			if err != nil {
 				return nil, err
 			}
-			namespaces[resource.ID] = *namespace
+			namespaces[resource.ID] = *namespaceCollection
 		}
 	}
 	return namespaces, nil

--- a/config/config.go
+++ b/config/config.go
@@ -127,9 +127,10 @@ type Credentials struct {
 
 // Target represents Azure target resource and its associated metric definitions
 type Target struct {
-	Resource     string   `yaml:"resource"`
-	Metrics      []Metric `yaml:"metrics"`
-	Aggregations []string `yaml:"aggregations"`
+	Resource        string   `yaml:"resource"`
+	MetricNamespace string   `yaml:"metric_namespace"`
+	Metrics         []Metric `yaml:"metrics"`
+	Aggregations    []string `yaml:"aggregations"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }
@@ -137,6 +138,7 @@ type Target struct {
 // ResourceGroup represents Azure target resource group and its associated metric definitions
 type ResourceGroup struct {
 	ResourceGroup         string   `yaml:"resource_group"`
+	MetricNamespace       string   `yaml:"metric_namespace"`
 	ResourceTypes         []string `yaml:"resource_types"`
 	ResourceNameIncludeRe []Regexp `yaml:"resource_name_include_re"`
 	ResourceNameExcludeRe []Regexp `yaml:"resource_name_exclude_re"`
@@ -150,6 +152,7 @@ type ResourceGroup struct {
 type ResourceTag struct {
 	ResourceTagName  string   `yaml:"resource_tag_name"`
 	ResourceTagValue string   `yaml:"resource_tag_value"`
+	MetricNamespace  string   `yaml:"metric_namespace"`
 	ResourceTypes    []string `yaml:"resource_types"`
 	Metrics          []Metric `yaml:"metrics"`
 	Aggregations     []string `yaml:"aggregations"`

--- a/main.go
+++ b/main.go
@@ -344,7 +344,7 @@ func main() {
 		}
 
 		for k, v := range results {
-			log.Printf("Resource: %s\n\nAvailable namespaces:\n", strings.Split(k, "/")[6])
+			log.Printf("Resource: %s\n\nAvailable namespaces:\n", k)
 			for _, namespace := range v.MetricNamespaceCollection {
 				log.Printf("- %s\n", namespace.Properties.MetricNamespaceName)
 			}

--- a/main.go
+++ b/main.go
@@ -73,6 +73,9 @@ func (c *Collector) extractMetrics(ch chan<- prometheus.Metric, rm resourceMeta,
 		metricName := strings.Replace(value.Name.Value, " ", "_", -1)
 		metricName = strings.ToLower(metricName + "_" + value.Unit)
 		metricName = strings.Replace(metricName, "/", "_per_", -1)
+		if rm.metricNamespace != "" {
+			metricName = strings.ToLower(rm.metricNamespace + "_" + metricName)
+		}
 		metricName = invalidMetricChars.ReplaceAllString(metricName, "_")
 
 		if len(value.Timeseries) > 0 {

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ var (
 	configFile            = kingpin.Flag("config.file", "Azure exporter configuration file.").Default("azure.yml").String()
 	listenAddress         = kingpin.Flag("web.listen-address", "The address to listen on for HTTP requests.").Default(":9276").String()
 	listMetricDefinitions = kingpin.Flag("list.definitions", "List available metric definitions for the given resources and exit.").Bool()
+	listMetricNamespaces  = kingpin.Flag("list.namespaces", "List available metric namespaces for the given resources and exit.").Bool()
 	invalidMetricChars    = regexp.MustCompile("[^a-zA-Z0-9_:]")
 	azureErrorDesc        = prometheus.NewDesc("azure_error", "Error collecting metrics", nil, nil)
 	batchSize             = 20
@@ -326,6 +327,22 @@ func main() {
 			log.Printf("Resource: %s\n\nAvailable Metrics:\n", strings.Split(k, "/")[6])
 			for _, r := range v.MetricDefinitionResponses {
 				log.Printf("- %s\n", r.Name.Value)
+			}
+		}
+		os.Exit(0)
+	}
+
+	// Print list of available metric namespace for each resource to console if specified.
+	if *listMetricNamespaces {
+		results, err := ac.getMetricNamespaces()
+		if err != nil {
+			log.Fatalf("Failed to fetch metric namespaces: %v", err)
+		}
+
+		for k, v := range results {
+			log.Printf("Resource: %s\n\nAvailable namespaces:\n", strings.Split(k, "/")[6])
+			for _, namespace := range v.MetricNamespaceCollection {
+				log.Printf("- %s\n", namespace.Properties.MetricNamespaceName)
 			}
 		}
 		os.Exit(0)


### PR DESCRIPTION
Hi @brian-brazil !

Azure Monitor API have a metric namespace concept that is not supported in the exporter. In Azure Monitor API, metrics are returned for the default namespace, but a custom namespace can be used for custom metrics. One of the use case we need this feature for is to access the guest OS performance counters, but the goal here is to support [custom metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview) in general (a custom namespace must be passed to the API query in order to access those).

This PR adds the following:
- a new optional `metric_namespace` property to specify namespace of the metrics to gather
- a new `--list.namespaces` CLI flag to list available metric namespaces for the given resources
- modified `--list.definitions` to support the optional namespace when listing available metric definitions for the given resources

Thanks!
