### PR TITLE
Metrics name, tags & help improvements

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -128,6 +128,7 @@ type Credentials struct {
 // Target represents Azure target resource and its associated metric definitions
 type Target struct {
 	Resource        string   `yaml:"resource"`
+	ResourceName    string   `yaml:"resource_name,omitempty"`
 	MetricNamespace string   `yaml:"metric_namespace"`
 	Metrics         []Metric `yaml:"metrics"`
 	Aggregations    []string `yaml:"aggregations"`
@@ -139,6 +140,7 @@ type Target struct {
 type ResourceGroup struct {
 	ResourceGroup         string   `yaml:"resource_group"`
 	MetricNamespace       string   `yaml:"metric_namespace"`
+	ResourceName          string   `yaml:"resource_name,omitempty"`
 	ResourceTypes         []string `yaml:"resource_types"`
 	ResourceNameIncludeRe []Regexp `yaml:"resource_name_include_re"`
 	ResourceNameExcludeRe []Regexp `yaml:"resource_name_exclude_re"`
@@ -153,6 +155,7 @@ type ResourceTag struct {
 	ResourceTagName  string   `yaml:"resource_tag_name"`
 	ResourceTagValue string   `yaml:"resource_tag_value"`
 	MetricNamespace  string   `yaml:"metric_namespace"`
+	ResourceName     string   `yaml:"resource_name,omitempty"`
 	ResourceTypes    []string `yaml:"resource_types"`
 	Metrics          []Metric `yaml:"metrics"`
 	Aggregations     []string `yaml:"aggregations"`

--- a/utils.go
+++ b/utils.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	// resource component positions in a ResourceURL
+	azureSubscriptionPosition  = 2
 	resourceGroupPosition      = 4
 	resourceNamePosition       = 8
 	subResourceNamePosition    = 10
@@ -46,7 +47,9 @@ func CreateResourceLabels(resourceURL string) map[string]string {
 	labels := make(map[string]string)
 	resource := strings.Split(resourceURL, "/")
 
+	labels["subscription"] = resource[azureSubscriptionPosition]
 	labels["resource_group"] = resource[resourceGroupPosition]
+	labels["resource_type"] = resource[resourceTypePrefixPosition]
 	labels["resource_name"] = resource[resourceNamePosition]
 	if len(resource) > 13 {
 		labels["sub_resource_name"] = resource[subResourceNamePosition]


### PR DESCRIPTION
New metrics tags added:
- subscription id - helpful, when metrics from different subscriptions are monitored by one Prometheus instance
- resource type - helpful, when metrics are filtered by tags

Resource name added to Target, ResourceGroup, and ResourceTag. When set, value is used as metrics name prefix (helpful when many resources from different subscriptions are monitored by one Prometheus instance).
