### PR TITLE
Fix: Make ResourceTypes optional for ResourceTag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -108,10 +108,6 @@ func (c *Config) Validate() (err error) {
 			return fmt.Errorf("resource_tag_value needs to be specified in each resource tag")
 		}
 
-		if len(t.ResourceTypes) == 0 {
-			return fmt.Errorf("At lease one resource type needs to be specified in each resource tag")
-		}
-
 		if len(t.Metrics) == 0 {
 			return fmt.Errorf("At least one metric needs to be specified in each resource tag")
 		}


### PR DESCRIPTION
> resource_types: optional list of types kept in the list of resources gathered by tag. If none are specified, then all the resources are kept. All defined metrics must exist for each processed resource.

I made it required in #88 