### PR TITLE
add resource type to metrics

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -48,6 +48,7 @@ func CreateResourceLabels(resourceURL string) map[string]string {
 
 	labels["resource_group"] = resource[resourceGroupPosition]
 	labels["resource_name"] = resource[resourceNamePosition]
+	labels["resource_type"] = resource[resourceTypePrefixPosition] + "/" + resource[resourceTypePosition]
 	if len(resource) > 13 {
 		labels["sub_resource_name"] = resource[subResourceNamePosition]
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -12,11 +12,11 @@ func TestCreateResourceLabels(t *testing.T) {
 	}{
 		{
 			"/subscriptions/abc123d4-e5f6-g7h8-i9j10-a1b2c3d4e5f6/resourceGroups/prod-rg-001/providers/Microsoft.Compute/virtualMachines/prod-vm-01/providers/microsoft.insights/metrics",
-			map[string]string{"resource_group": "prod-rg-001", "resource_name": "prod-vm-01"},
+			map[string]string{"resource_group": "prod-rg-001", "resource_name": "prod-vm-01", "resource_type": "Microsoft.Compute/virtualMachines"},
 		},
 		{
 			"/subscriptions/abc123d4-e5f6-g7h8-i9j10-a1b2c3d4e5f6/resourceGroups/prod-rg-002/providers/Microsoft.Sql/servers/sqlprod/databases/prod-db-01/providers/microsoft.insights/metrics",
-			map[string]string{"resource_group": "prod-rg-002", "resource_name": "sqlprod", "sub_resource_name": "prod-db-01"},
+			map[string]string{"resource_group": "prod-rg-002", "resource_name": "sqlprod", "sub_resource_name": "prod-db-01", "resource_type": "Microsoft.Sql/servers"},
 		},
 	}
 


### PR DESCRIPTION
- add resource type to metrics

the prefix and main resource type seems to be enough without the suffix.