### PR TITLE
Allow to specify custom time range for metrics query

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -584,7 +584,7 @@ type batchRequest struct {
 	Method      string `json:"httpMethod"`
 }
 
-func resourceURLFrom(resource string, metricNamespace string, metricNames string, aggregations []string) string {
+func resourceURLFrom(resource string, metricNamespace string, metricNames string, aggregations []string, rangeSeconds, offsetSeconds *int) string {
 	apiVersion := "2018-01-01"
 
 	path := fmt.Sprintf(
@@ -593,7 +593,7 @@ func resourceURLFrom(resource string, metricNamespace string, metricNames string
 		resource,
 	)
 
-	endTime, startTime := GetTimes()
+	endTime, startTime := GetTimes(rangeSeconds, offsetSeconds)
 
 	values := url.Values{}
 	if metricNames != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,8 @@ type Target struct {
 	MetricNamespace string   `yaml:"metric_namespace"`
 	Metrics         []Metric `yaml:"metrics"`
 	Aggregations    []string `yaml:"aggregations"`
+	RangeSeconds    *int     `yaml:"range_seconds"`
+	OffsetSeconds   *int     `yaml:"offset_seconds"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }
@@ -162,6 +164,8 @@ type ResourceGroup struct {
 	ResourceNameExcludeRe []Regexp `yaml:"resource_name_exclude_re"`
 	Metrics               []Metric `yaml:"metrics"`
 	Aggregations          []string `yaml:"aggregations"`
+	RangeSeconds          *int     `yaml:"range_seconds"`
+	OffsetSeconds         *int     `yaml:"offset_seconds"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }
@@ -174,6 +178,8 @@ type ResourceTag struct {
 	ResourceTypes    []string `yaml:"resource_types"`
 	Metrics          []Metric `yaml:"metrics"`
 	Aggregations     []string `yaml:"aggregations"`
+	RangeSeconds     *int     `yaml:"range_seconds"`
+	OffsetSeconds    *int     `yaml:"offset_seconds"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/main.go
+++ b/main.go
@@ -234,7 +234,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		rm.metricNamespace = target.MetricNamespace
 		rm.metrics = strings.Join(metrics, ",")
 		rm.aggregations = filterAggregations(target.Aggregations)
-		rm.resourceURL = resourceURLFrom(target.Resource, rm.metricNamespace, rm.metrics, rm.aggregations)
+		rm.resourceURL = resourceURLFrom(target.Resource, rm.metricNamespace, rm.metrics, rm.aggregations, target.RangeSeconds, target.OffsetSeconds)
 		incompleteResources = append(incompleteResources, rm)
 	}
 
@@ -259,7 +259,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			rm.metricNamespace = resourceGroup.MetricNamespace
 			rm.metrics = metricsStr
 			rm.aggregations = filterAggregations(resourceGroup.Aggregations)
-			rm.resourceURL = resourceURLFrom(f.ID, rm.metricNamespace, rm.metrics, rm.aggregations)
+			rm.resourceURL = resourceURLFrom(f.ID, rm.metricNamespace, rm.metrics, rm.aggregations, resourceGroup.RangeSeconds, resourceGroup.OffsetSeconds)
 			rm.resource = f
 			resources = append(resources, rm)
 		}
@@ -287,7 +287,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			rm.metricNamespace = resourceTag.MetricNamespace
 			rm.metrics = metricsStr
 			rm.aggregations = filterAggregations(resourceTag.Aggregations)
-			rm.resourceURL = resourceURLFrom(f.ID, rm.metricNamespace, rm.metrics, rm.aggregations)
+			rm.resourceURL = resourceURLFrom(f.ID, rm.metricNamespace, rm.metrics, rm.aggregations, resourceTag.RangeSeconds, resourceTag.OffsetSeconds)
 			incompleteResources = append(incompleteResources, rm)
 		}
 	}

--- a/utils.go
+++ b/utils.go
@@ -31,13 +31,22 @@ func PrintPrettyJSON(input map[string]interface{}) {
 }
 
 // GetTimes - Returns the endTime and startTime used for querying Azure Metrics API
-func GetTimes() (string, string) {
+func GetTimes(rangeSeconds, offsetSeconds *int) (string, string) {
 	// Make sure we are using UTC
 	now := time.Now().UTC()
 
+	if offsetSeconds == nil {
+		offsetSecondsDefault := 3 * 60
+		offsetSeconds = &offsetSecondsDefault
+	}
+	if rangeSeconds == nil {
+		rangeSecondsDefault := 60
+		rangeSeconds = &rangeSecondsDefault
+	}
+
 	// Use query delay of 3 minutes when querying for latest metric data
-	endTime := now.Add(time.Minute * time.Duration(-3)).Format(time.RFC3339)
-	startTime := now.Add(time.Minute * time.Duration(-4)).Format(time.RFC3339)
+	endTime := now.Add(time.Duration(-*offsetSeconds) * time.Second).Format(time.RFC3339)
+	startTime := now.Add(time.Duration(-*rangeSeconds-*offsetSeconds) * time.Second).Format(time.RFC3339)
 	return endTime, startTime
 }
 


### PR DESCRIPTION
Stumbled on a problem trying to get a storageaccount UsedCapacity. 
Seems like Azure doesn't allow to query this metric using the default range (1minute), but needs a bigger range (>1h)
This pull request adds the range_seconds and offset_seconds, which are used to get the start/end time for the metrics query.

```
resource_tags:
  - resource_tag_name: "monitoring"
    resource_tag_value: "prometheus"
    resource_types:
      - "Microsoft.Storage/storageAccounts"
    metric_namespace: "microsoft.storage/storageaccounts"
    metrics:
      - name: "UsedCapacity"
    range_seconds: 21600
    offset_seconds: 180
    aggregations:
      - "Average"
```